### PR TITLE
[FEAT] 카카오 로그인 및 JWT 인증 로직 구현

### DIFF
--- a/src/main/java/com/ssafy/foofa/FoofaApplication.java
+++ b/src/main/java/com/ssafy/foofa/FoofaApplication.java
@@ -2,7 +2,9 @@ package com.ssafy.foofa;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
+@ConfigurationPropertiesScan
 @SpringBootApplication
 public class FoofaApplication {
 

--- a/src/main/java/com/ssafy/foofa/chat/domain/Message.java
+++ b/src/main/java/com/ssafy/foofa/chat/domain/Message.java
@@ -1,5 +1,6 @@
 package com.ssafy.foofa.chat.domain;
 
+import com.ssafy.foofa.core.ErrorCode;
 import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.Indexed;
@@ -119,7 +120,7 @@ public class Message {
      */
     public Message markAsRead(String userId) {
         if (!this.readBy.containsKey(userId)) {
-            throw new IllegalArgumentException("User not in readBy map");
+            throw new IllegalArgumentException(ErrorCode.USER_NOT_IN_READBY_MAP.getMessage());
         }
 
         Map<String, LocalDateTime> updatedReadBy = new HashMap<>(this.readBy);

--- a/src/main/java/com/ssafy/foofa/core/ErrorCode.java
+++ b/src/main/java/com/ssafy/foofa/core/ErrorCode.java
@@ -2,53 +2,54 @@ package com.ssafy.foofa.core;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-
-import static org.springframework.http.HttpStatus.*;
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
-    // Common
-    INVALID_JSON(BAD_REQUEST,"잘못된 JSON 형식입니다. 요청 데이터를 확인하세요."),
-    FIELD_ERROR(BAD_REQUEST,"입력이 잘못되었습니다."),
-    URL_PARAMETER_ERROR(BAD_REQUEST,"입력이 잘못되었습니다."),
-    METHOD_ARGUMENT_TYPE_MISMATCH(BAD_REQUEST,"입력한 값의 타입이 잘못되었습니다."),
-    ALREADY_DISCONNECTED(BAD_REQUEST,"이미 클라이언트에서 요청이 종료되었습니다."),
-    NO_RESOURCE_FOUND(NOT_FOUND,"요청한 리소스를 찾을 수 없습니다."),
-    METHOD_NOT_SUPPORTED(METHOD_NOT_ALLOWED,"허용되지 않은 메서드입니다."),
-    MEDIA_TYPE_NOT_SUPPORTED(UNSUPPORTED_MEDIA_TYPE,"허용되지 않은 미디어 타입입니다."),
-    SERVER_ERROR(INTERNAL_SERVER_ERROR,"서버 오류가 발생했습니다. 관리자에게 문의해주세요."),
-    REDIS_UNAVAILABLE(SERVICE_UNAVAILABLE,"Redis 서버에 연결할 수 없습니다."),
-    EVENT_SERIALIZATION_FAILED(INTERNAL_SERVER_ERROR, "이벤트 직렬화 중 오류가 발생했습니다."),
+    // Validation
+    INVALID_JSON("잘못된 JSON 형식입니다. 요청 데이터를 확인하세요."),
+    INVALID_INPUT("입력이 잘못되었습니다."),
+    MISSING_PARAMETER("필수 파라미터가 누락되었습니다."),
+    INVALID_TYPE("입력한 값의 타입이 잘못되었습니다."),
+    CLIENT_DISCONNECTED("이미 클라이언트에서 요청이 종료되었습니다."),
+    RESOURCE_NOT_FOUND("요청한 리소스를 찾을 수 없습니다."),
+    METHOD_NOT_SUPPORTED("허용되지 않은 메서드입니다."),
+    MEDIA_TYPE_NOT_SUPPORTED("허용되지 않은 미디어 타입입니다."),
+    SERVER_ERROR("서버 오류가 발생했습니다. 관리자에게 문의해주세요."),
+
+    // User
+    USER_NOT_FOUND("회원을 찾을 수 없습니다. UserId: %s"),
 
     // Token
-    INVALID_TOKEN_HEADER(UNAUTHORIZED, "토큰 헤더 형식이 잘못되었습니다."),
-    TOKEN_INVALID(UNAUTHORIZED, "유효하지 않은 토큰입니다. 다시 로그인해 주세요."),
-    TOKEN_MISSING(UNAUTHORIZED, "토큰이 요청 헤더에 없습니다. 새로운 토큰을 재발급 받으세요"),
-    TOKEN_BLACKLISTED(UNAUTHORIZED, "해당 토큰은 사용이 금지되었습니다. 다시 로그인해 주세요."),
-    TOKEN_EXPIRED(UNAUTHORIZED, "토큰이 만료되었습니다. 새로운 토큰을 재발급 받으세요."),
-    REFRESH_TOKEN_EXPIRED(UNAUTHORIZED, "리프레쉬 토큰이 만료되었습니다. 다시 로그인해 주세요."),
+    TOKEN_EXPIRED("토큰이 만료되었습니다. 새로운 토큰을 재발급 받으세요."),
+    TOKEN_INVALID("유효하지 않은 토큰입니다. 다시 로그인해 주세요."),
+    REFRESH_TOKEN_EXPIRED("리프레시 토큰이 만료되었습니다. 다시 로그인해 주세요."),
+    TOKEN_HEADER_INVALID("토큰 헤더 형식이 잘못되었습니다."),
+    TOKEN_MISSING("토큰이 요청 헤더에 없습니다. 새로운 토큰을 재발급 받으세요."),
+    TOKEN_BLACKLISTED("해당 토큰은 사용이 금지되었습니다. 다시 로그인해 주세요."),
 
     // OAuth
-    UNSUPPORTED_SOCIAL_LOGIN(BAD_REQUEST, "지원하지 않는 소셜 로그인 타입입니다. type : %s"),
-    OAUTH_USER_FETCH_FAILED(SERVICE_UNAVAILABLE, "%s 사용자 정보를 가져오는 데 실패했습니다. 잠시 후 다시 시도해주세요."),
-    APPLE_AUTHORIZATION_CODE_EXPIRED(UNAUTHORIZED, "애플 Authorization Code가 만료되었거나 잘못되었습니다. 다시 시도해주세요."),
-    APPLE_SIGNATURE_INVALID(UNAUTHORIZED, "애플 id_token 서명 검증에 실패했습니다. 위조되었을 가능성이 있습니다."),
-    APPLE_USER_PARSE_FAILED(NOT_FOUND, "애플 사용자 정보를 파싱하는 데 실패했습니다. id_token 구조를 확인하세요."),
-    APPLE_PRIVATE_KEY_LOAD_FAILED(INTERNAL_SERVER_ERROR, "Apple 비공개 키 파일을 로드하는 데 실패했습니다. 파일 경로 또는 포맷을 확인하세요."),
+    UNSUPPORTED_OAUTH_PROVIDER("지원하지 않는 소셜 로그인 타입입니다. type: %s"),
+    OAUTH_USER_FETCH_FAILED("%s 사용자 정보를 가져오는 데 실패했습니다. 잠시 후 다시 시도해주세요."),
 
-    // Member
-    NOT_FOUND_MEMBER(NOT_FOUND, "회원을 찾을 수 없습니다. MemberId : %d"),
-    ALREADY_ONBOARDED_MEMBER(CONFLICT, "이미 온보딩을 완료한 회원입니다. MemberId : %d"),
-    NOT_FOUND_QUESTION(NOT_FOUND, "질문을 찾을 수 없습니다. QuestionId : %d"),
-    NOT_FOUND_ANSWER(NOT_FOUND, "답을 찾을 수 없습니다. AnswerId : %d"),
-    NOT_FOUND_HOME_ADDRESS(NOT_FOUND, "회원이 저장한 주소를 찾을 수 없습니다. MemberId : %d"),
-    UNSUPPORTED_MAP_PROVIDER(BAD_REQUEST, "지원하지 않는 지도 제공자입니다. MapProvider : %s"),
-    UNSUPPORTED_ADDRESS_TYPE(BAD_REQUEST, "지원하지 않는 주소 타입입니다. AddressType : %s"),
+    // Chat
+    USER_NOT_IN_READBY_MAP("사용자가 readBy 맵에 존재하지 않습니다."),
+
+    // Battle
+    BATTLE_ALREADY_FULL("대결에 이미 2명의 멤버가 있습니다."),
+    BATTLE_NEEDS_TWO_MEMBERS("대결을 시작하려면 정확히 2명의 멤버가 필요합니다."),
+    NO_CHEAT_DAYS_REMAINING("남은 치팅데이가 없습니다."),
+    OPPONENT_NOT_FOUND("상대방을 찾을 수 없습니다."),
+    MEMBER_NOT_FOUND("멤버를 찾을 수 없습니다."),
     ;
 
-    public final HttpStatus httpStatus;
     private final String message;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String format(Object... args) {
+        return String.format(message, args);
+    }
 }

--- a/src/main/java/com/ssafy/foofa/core/ErrorResponse.java
+++ b/src/main/java/com/ssafy/foofa/core/ErrorResponse.java
@@ -13,10 +13,7 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 @Schema(description = "API 에러 응답")
 public record ErrorResponse(
-        @Schema(description = "에러 코드", example = "TODO_LIMIT_EXCEEDED")
-        String errorCode,
-
-        @Schema(description = "에러 메시지", example = "오늘 할 일은 최대 3개까지 추가할 수 있습니다.")
+        @Schema(description = "에러 메시지", example = "회원을 찾을 수 없습니다.")
         String message,
 
         @JsonInclude(Include.NON_NULL)
@@ -28,22 +25,16 @@ public record ErrorResponse(
         List<ConstraintViolationError> violationErrors
 ) {
 
-    public ErrorResponse(ErrorCode errorCode) {
-        this(errorCode, null, null);
+    public ErrorResponse(String message) {
+        this(message, null, null);
     }
 
-    public ErrorResponse(ErrorCode errorCode, BindingResult bindingResult) {
-        this(errorCode, FieldError.from(bindingResult), null);
+    public ErrorResponse(String message, BindingResult bindingResult) {
+        this(message, FieldError.from(bindingResult), null);
     }
 
-    public ErrorResponse(ErrorCode errorCode, Set<ConstraintViolation<?>> constraintViolations) {
-        this(errorCode, null, ConstraintViolationError.from(constraintViolations));
-    }
-
-    private ErrorResponse(ErrorCode errorCode,
-                          List<FieldError> fieldErrors,
-                          List<ConstraintViolationError> violationErrors) {
-        this(errorCode.name(), errorCode.getMessage(), fieldErrors, violationErrors);
+    public ErrorResponse(String message, Set<ConstraintViolation<?>> constraintViolations) {
+        this(message, null, ConstraintViolationError.from(constraintViolations));
     }
 
     private record FieldError(String field, Object rejectedValue, String reason) {

--- a/src/main/java/com/ssafy/foofa/core/JwtProperties.java
+++ b/src/main/java/com/ssafy/foofa/core/JwtProperties.java
@@ -1,0 +1,11 @@
+package com.ssafy.foofa.core;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        String secret,
+        long accessTokenExpireTimeInHours,
+        long refreshTokenExpireTimeInHours
+) {
+}

--- a/src/main/java/com/ssafy/foofa/core/OauthProviderConverter.java
+++ b/src/main/java/com/ssafy/foofa/core/OauthProviderConverter.java
@@ -1,0 +1,19 @@
+package com.ssafy.foofa.core;
+
+import com.ssafy.foofa.identity.domain.enums.OauthProvider;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import static java.util.Locale.ENGLISH;
+
+@Component
+public class OauthProviderConverter implements Converter<String, OauthProvider> {
+    @Override
+    public OauthProvider convert(String type) {
+        try {
+            return OauthProvider.valueOf(type.toUpperCase(ENGLISH));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(ErrorCode.UNSUPPORTED_OAUTH_PROVIDER.format(type));
+        }
+    }
+}

--- a/src/main/java/com/ssafy/foofa/core/TokenExtractor.java
+++ b/src/main/java/com/ssafy/foofa/core/TokenExtractor.java
@@ -1,0 +1,18 @@
+package com.ssafy.foofa.core;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class TokenExtractor {
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    public static String extract(String header) {
+        if (header == null) {
+            throw new IllegalArgumentException(ErrorCode.TOKEN_MISSING.getMessage());
+        }
+        if (!header.startsWith(BEARER_PREFIX)) {
+            throw new IllegalArgumentException(ErrorCode.TOKEN_HEADER_INVALID.getMessage());
+        }
+        return header.substring(BEARER_PREFIX.length());
+    }
+}

--- a/src/main/java/com/ssafy/foofa/core/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ssafy/foofa/core/exception/GlobalExceptionHandler.java
@@ -23,84 +23,87 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleIllegalArgumentException(IllegalArgumentException e) {
+        log.warn(e.getMessage());
+        return new ErrorResponse(e.getMessage());
+    }
+
     @ExceptionHandler
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleBindingException(BindException e) {
         log.warn(e.getMessage());
-
-        return new ErrorResponse(ErrorCode.FIELD_ERROR, e.getBindingResult());
+        return new ErrorResponse(ErrorCode.INVALID_INPUT.getMessage(), e.getBindingResult());
     }
 
     @ExceptionHandler
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleConstraintViolationException(ConstraintViolationException e) {
         log.warn(e.getMessage());
-
-        return new ErrorResponse(ErrorCode.URL_PARAMETER_ERROR, e.getConstraintViolations());
+        return new ErrorResponse(ErrorCode.INVALID_INPUT.getMessage(), e.getConstraintViolations());
     }
 
     @ExceptionHandler(MissingServletRequestParameterException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleMissingParam(MissingServletRequestParameterException e) {
         log.warn(e.getMessage());
-        return new ErrorResponse(ErrorCode.URL_PARAMETER_ERROR);
+        return new ErrorResponse(ErrorCode.MISSING_PARAMETER.getMessage());
     }
 
     @ExceptionHandler
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
         log.warn(e.getMessage());
-
-        return new ErrorResponse(ErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH);
+        return new ErrorResponse(ErrorCode.INVALID_TYPE.getMessage());
     }
 
     @ExceptionHandler
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleClientAbortException(ClientAbortException e) {
         log.warn(e.getMessage());
-
-        return new ErrorResponse(ErrorCode.ALREADY_DISCONNECTED);
+        return new ErrorResponse(ErrorCode.CLIENT_DISCONNECTED.getMessage());
     }
 
     @ExceptionHandler
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
         log.warn(e.getMessage());
-
-        return new ErrorResponse(ErrorCode.INVALID_JSON);
+        return new ErrorResponse(ErrorCode.INVALID_JSON.getMessage());
     }
-
-
 
     @ExceptionHandler
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public ErrorResponse handleNoResourceFoundException(NoResourceFoundException e) {
         log.warn(e.getMessage());
-
-        return new ErrorResponse(ErrorCode.NO_RESOURCE_FOUND);
+        return new ErrorResponse(ErrorCode.RESOURCE_NOT_FOUND.getMessage());
     }
 
     @ExceptionHandler
     @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
     public ErrorResponse handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
         log.warn(e.getMessage());
-
-        return new ErrorResponse(ErrorCode.METHOD_NOT_SUPPORTED);
+        return new ErrorResponse(ErrorCode.METHOD_NOT_SUPPORTED.getMessage());
     }
 
     @ExceptionHandler
     @ResponseStatus(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
     public ErrorResponse handleHttpMediaTypeNotSupportedException(HttpMediaTypeNotSupportedException e) {
         log.warn(e.getMessage());
-
-        return new ErrorResponse(ErrorCode.MEDIA_TYPE_NOT_SUPPORTED);
+        return new ErrorResponse(ErrorCode.MEDIA_TYPE_NOT_SUPPORTED.getMessage());
     }
 
     @ExceptionHandler
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ErrorResponse handleException(Exception e) {
         log.error(e.getMessage(), e);
+        return new ErrorResponse(ErrorCode.SERVER_ERROR.getMessage());
+    }
 
-        return new ErrorResponse(ErrorCode.SERVER_ERROR);
+    @ExceptionHandler(IllegalStateException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ErrorResponse handleIllegalStateException(IllegalStateException e) {
+        log.error(e.getMessage(), e);
+        return new ErrorResponse(e.getMessage());
     }
 }

--- a/src/main/java/com/ssafy/foofa/identity/application/AuthFacade.java
+++ b/src/main/java/com/ssafy/foofa/identity/application/AuthFacade.java
@@ -1,0 +1,32 @@
+package com.ssafy.foofa.identity.application;
+
+import com.ssafy.foofa.identity.domain.OauthApi;
+import com.ssafy.foofa.identity.domain.OauthApiFactory;
+import com.ssafy.foofa.identity.domain.User;
+import com.ssafy.foofa.identity.domain.dto.UserInfo;
+import com.ssafy.foofa.identity.domain.enums.OauthProvider;
+import com.ssafy.foofa.identity.domain.service.UserService;
+import com.ssafy.foofa.identity.presentation.dto.LoginResponse;
+import com.ssafy.foofa.identity.presentation.dto.Token;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthFacade {
+    private final TokenFacade tokenFacade;
+    private final OauthApiFactory oauthApiFactory;
+    private final UserService userService;
+
+    @Transactional
+    public LoginResponse loginWithOAuth(OauthProvider oauthProvider, String accessToken) {
+        OauthApi oauthApi = oauthApiFactory.getOauthApi(oauthProvider);
+        UserInfo userInfo = oauthApi.fetchUser(accessToken);
+
+        User user = userService.findOrRegisterOauthUser(userInfo, oauthProvider);
+        Token token = tokenFacade.issue(user.getId());
+
+        return LoginResponse.of(user.getId(), token.accessToken(), token.refreshToken());
+    }
+}

--- a/src/main/java/com/ssafy/foofa/identity/application/TokenFacade.java
+++ b/src/main/java/com/ssafy/foofa/identity/application/TokenFacade.java
@@ -1,0 +1,40 @@
+package com.ssafy.foofa.identity.application;
+
+import com.ssafy.foofa.core.JwtProperties;
+import com.ssafy.foofa.identity.presentation.dto.Token;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenFacade {
+    public static final long HOURS_IN_MILLIS = 60 * 60 * 1000L;
+
+    private final JwtProperties jwtProperties;
+    private final TokenManager tokenManager;
+    private long accessTokenTime;
+    private long refreshTokenTime;
+
+    @PostConstruct
+    public void init() {
+        this.accessTokenTime = jwtProperties.accessTokenExpireTimeInHours() * HOURS_IN_MILLIS;
+        this.refreshTokenTime = jwtProperties.refreshTokenExpireTimeInHours() * HOURS_IN_MILLIS;
+    }
+
+    public Token issue(String memberId) {
+        String newAccessToken = tokenManager.createToken(memberId, accessTokenTime);
+        String newRefreshToken = tokenManager.createToken(memberId, refreshTokenTime);
+
+        return new Token(newAccessToken, newRefreshToken);
+    }
+
+    public Token reissue(String oldRefreshToken) {
+        TokenInfo tokenInfo = tokenManager.parseClaimsFromRefreshToken(oldRefreshToken);
+        String memberId = tokenInfo.memberId();
+
+        return issue(memberId);
+    }
+}

--- a/src/main/java/com/ssafy/foofa/identity/application/TokenInfo.java
+++ b/src/main/java/com/ssafy/foofa/identity/application/TokenInfo.java
@@ -1,0 +1,10 @@
+package com.ssafy.foofa.identity.application;
+
+import java.time.Instant;
+
+public record TokenInfo(
+        String tokenId,
+        String memberId,
+        Instant expiration
+) {
+}

--- a/src/main/java/com/ssafy/foofa/identity/application/TokenManager.java
+++ b/src/main/java/com/ssafy/foofa/identity/application/TokenManager.java
@@ -1,0 +1,78 @@
+package com.ssafy.foofa.identity.application;
+
+import com.ssafy.foofa.core.ErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+import java.util.UUID;
+
+@Component
+public class TokenManager {
+    public static final String TOKEN_ISSUER = "FOOFA";
+
+    @Value("${jwt.secret}")
+    private String secret;
+    private SecretKey secretKey;
+
+    @PostConstruct
+    public void initKey() {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        secretKey = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String createToken(String memberId, long expirationTime) {
+        Claims claims = Jwts.claims().subject(memberId).build();
+        String jti = UUID.randomUUID().toString().substring(0, 16) + memberId;
+        Date now = new Date();
+
+        return Jwts.builder()
+                .id(jti)
+                .issuer(TOKEN_ISSUER)
+                .claims(claims)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + expirationTime))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public TokenInfo parseClaims(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .requireIssuer(TOKEN_ISSUER)
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+            return new TokenInfo(claims.getId(), claims.getSubject(), claims.getExpiration().toInstant());
+        } catch (ExpiredJwtException ex) {
+            throw new IllegalArgumentException(ErrorCode.TOKEN_EXPIRED.getMessage());
+        } catch (JwtException ex) {
+            throw new IllegalArgumentException(ErrorCode.TOKEN_INVALID.getMessage());
+        }
+    }
+
+    public TokenInfo parseClaimsFromRefreshToken(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .requireIssuer(TOKEN_ISSUER)
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+            return new TokenInfo(claims.getId(), claims.getSubject(), claims.getExpiration().toInstant());
+        } catch (ExpiredJwtException ex) {
+            throw new IllegalArgumentException(ErrorCode.REFRESH_TOKEN_EXPIRED.getMessage());
+        } catch (JwtException ex) {
+            throw new IllegalArgumentException(ErrorCode.TOKEN_INVALID.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/ssafy/foofa/identity/application/UserFacade.java
+++ b/src/main/java/com/ssafy/foofa/identity/application/UserFacade.java
@@ -1,0 +1,22 @@
+package com.ssafy.foofa.identity.application;
+
+import com.ssafy.foofa.identity.domain.User;
+import com.ssafy.foofa.identity.domain.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserFacade {
+    private final UserService userService;
+
+    public User getUser(String userId) {
+        return userService.getUserIfExists(userId);
+    }
+
+    @Transactional
+    public void deleteUser(String userId, Long withdrawalReasonId, String customReason) {
+        userService.deleteUser(userId);
+    }
+}

--- a/src/main/java/com/ssafy/foofa/identity/domain/OauthApi.java
+++ b/src/main/java/com/ssafy/foofa/identity/domain/OauthApi.java
@@ -1,0 +1,7 @@
+package com.ssafy.foofa.identity.domain;
+
+import com.ssafy.foofa.identity.domain.dto.UserInfo;
+
+public interface OauthApi {
+    UserInfo fetchUser(String accessToken);
+}

--- a/src/main/java/com/ssafy/foofa/identity/domain/OauthApiFactory.java
+++ b/src/main/java/com/ssafy/foofa/identity/domain/OauthApiFactory.java
@@ -1,0 +1,7 @@
+package com.ssafy.foofa.identity.domain;
+
+import com.ssafy.foofa.identity.domain.enums.OauthProvider;
+
+public interface OauthApiFactory {
+    OauthApi getOauthApi(OauthProvider provider);
+}

--- a/src/main/java/com/ssafy/foofa/identity/domain/dto/UserInfo.java
+++ b/src/main/java/com/ssafy/foofa/identity/domain/dto/UserInfo.java
@@ -1,0 +1,7 @@
+package com.ssafy.foofa.identity.domain.dto;
+
+public record UserInfo(
+        String oauthProviderId,
+        String email
+) {
+}

--- a/src/main/java/com/ssafy/foofa/identity/domain/enums/OauthProvider.java
+++ b/src/main/java/com/ssafy/foofa/identity/domain/enums/OauthProvider.java
@@ -1,0 +1,6 @@
+package com.ssafy.foofa.identity.domain.enums;
+
+public enum OauthProvider {
+    KAKAO
+    ;
+}

--- a/src/main/java/com/ssafy/foofa/identity/domain/repository/UserRepository.java
+++ b/src/main/java/com/ssafy/foofa/identity/domain/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.ssafy.foofa.identity.domain.repository;
+
+import com.ssafy.foofa.identity.domain.User;
+import com.ssafy.foofa.identity.domain.enums.OauthProvider;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends MongoRepository<User, String> {
+    Optional<User> findByOauthInfoProviderIdAndOauthInfoProvider(String providerId, OauthProvider provider);
+}

--- a/src/main/java/com/ssafy/foofa/identity/domain/service/UserService.java
+++ b/src/main/java/com/ssafy/foofa/identity/domain/service/UserService.java
@@ -1,0 +1,45 @@
+package com.ssafy.foofa.identity.domain.service;
+
+import com.ssafy.foofa.core.ErrorCode;
+import com.ssafy.foofa.identity.domain.User;
+import com.ssafy.foofa.identity.domain.dto.UserInfo;
+import com.ssafy.foofa.identity.domain.enums.OauthProvider;
+import com.ssafy.foofa.identity.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+    private final UserRepository userRepository;
+
+    public User getUserIfExists(String userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.USER_NOT_FOUND.format(userId)));
+    }
+
+    @Transactional
+    public User findOrRegisterOauthUser(UserInfo userInfo, OauthProvider oauthProvider) {
+        return userRepository.findByOauthInfoProviderIdAndOauthInfoProvider(
+                        userInfo.oauthProviderId(),
+                        oauthProvider
+                )
+                .orElseGet(() -> registerUserWithOauth(userInfo, oauthProvider));
+    }
+
+    private User registerUserWithOauth(UserInfo userInfo, OauthProvider oauthProvider) {
+        User newUser = User.registerWithOauth(
+                userInfo.email(),
+                oauthProvider,
+                userInfo.oauthProviderId()
+        );
+        return userRepository.save(newUser);
+    }
+
+    @Transactional
+    public void deleteUser(String userId) {
+        userRepository.deleteById(userId);
+    }
+}

--- a/src/main/java/com/ssafy/foofa/identity/infra/dto/KakaoUserInfoResponse.java
+++ b/src/main/java/com/ssafy/foofa/identity/infra/dto/KakaoUserInfoResponse.java
@@ -1,0 +1,11 @@
+package com.ssafy.foofa.identity.infra.dto;
+
+public record KakaoUserInfoResponse(
+        Long id,
+        KakaoAccount kakao_account
+) {
+    public record KakaoAccount(
+            String email
+    ) {
+    }
+}

--- a/src/main/java/com/ssafy/foofa/identity/infra/oauth/KakaoOauthApi.java
+++ b/src/main/java/com/ssafy/foofa/identity/infra/oauth/KakaoOauthApi.java
@@ -1,0 +1,57 @@
+package com.ssafy.foofa.identity.infra.oauth;
+
+import com.ssafy.foofa.core.ErrorCode;
+import com.ssafy.foofa.identity.domain.OauthApi;
+import com.ssafy.foofa.identity.domain.dto.UserInfo;
+import com.ssafy.foofa.identity.domain.enums.OauthProvider;
+import com.ssafy.foofa.identity.infra.dto.KakaoUserInfoResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoOauthApi implements OauthApi {
+    private static final String USERINFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+    private final RestClient restClient = RestClient.create();
+
+    @Override
+    @Retryable(
+            retryFor = { Exception.class },
+            maxAttempts = 2,
+            backoff = @Backoff(delay = 500)
+    )
+    public UserInfo fetchUser(String accessToken) {
+        try {
+            KakaoUserInfoResponse response = restClient.get()
+                    .uri(USERINFO_URL)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .body(KakaoUserInfoResponse.class);
+
+            String oauthProviderId = String.valueOf(response.id());
+            String email = response.kakao_account().email();
+
+            return new UserInfo(oauthProviderId, email);
+        } catch (RestClientResponseException ex) {
+            log.error(
+                    "Kakao API error: status={} responseBody={}",
+                    ex.getRawStatusCode(),
+                    ex.getResponseBodyAsString(),
+                    ex
+            );
+            throw new IllegalStateException(ErrorCode.OAUTH_USER_FETCH_FAILED.format(OauthProvider.KAKAO.name()));
+
+        } catch (RestClientException ex) {
+            log.error("Failed to call Kakao userinfo endpoint", ex);
+            throw new IllegalStateException(ErrorCode.OAUTH_USER_FETCH_FAILED.format(OauthProvider.KAKAO.name()));
+        }
+    }
+}

--- a/src/main/java/com/ssafy/foofa/identity/infra/oauth/OauthApiFactoryImpl.java
+++ b/src/main/java/com/ssafy/foofa/identity/infra/oauth/OauthApiFactoryImpl.java
@@ -1,0 +1,32 @@
+package com.ssafy.foofa.identity.infra.oauth;
+
+import com.ssafy.foofa.core.ErrorCode;
+import com.ssafy.foofa.identity.domain.OauthApi;
+import com.ssafy.foofa.identity.domain.OauthApiFactory;
+import com.ssafy.foofa.identity.domain.enums.OauthProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class OauthApiFactoryImpl implements OauthApiFactory {
+    private final Map<OauthProvider, OauthApi> oauthApiMap;
+
+    @Autowired
+    public OauthApiFactoryImpl(List<OauthApi> oauthApis) {
+        oauthApiMap = Map.of(
+                OauthProvider.KAKAO, oauthApis.stream().filter(api -> api instanceof KakaoOauthApi).findFirst().orElseThrow()
+        );
+    }
+
+    @Override
+    public OauthApi getOauthApi(OauthProvider provider) {
+        return Optional.ofNullable(oauthApiMap.get(provider))
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.UNSUPPORTED_OAUTH_PROVIDER.format(provider.name())));
+    }
+}

--- a/src/main/java/com/ssafy/foofa/identity/presentation/AuthController.java
+++ b/src/main/java/com/ssafy/foofa/identity/presentation/AuthController.java
@@ -1,0 +1,58 @@
+package com.ssafy.foofa.identity.presentation;
+
+import com.ssafy.foofa.identity.application.AuthFacade;
+import com.ssafy.foofa.identity.application.TokenFacade;
+import com.ssafy.foofa.identity.domain.enums.OauthProvider;
+import com.ssafy.foofa.identity.presentation.dto.AccessToken;
+import com.ssafy.foofa.identity.presentation.dto.LoginResponse;
+import com.ssafy.foofa.identity.presentation.dto.Token;
+import com.ssafy.foofa.identity.presentation.swagger.AuthSwagger;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController implements AuthSwagger {
+    private final AuthFacade authFacade;
+    private final TokenFacade tokenFacade;
+
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping("/login/oauth")
+    public LoginResponse loginWithOAuth(
+            @RequestParam("provider") OauthProvider oauthProvider,
+            @RequestParam("access_token") String accessToken
+    ) {
+        return authFacade.loginWithOAuth(oauthProvider, accessToken);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping("/reissue")
+    public Token reissue(
+            @CookieValue("refreshToken") String refreshToken
+    ) {
+        return tokenFacade.reissue(refreshToken);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PostMapping("/logout")
+    public void logout(
+            HttpServletResponse response
+    ) {
+        Cookie cookie = new Cookie("refreshToken", "");
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        response.addCookie(cookie);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping("/test/token")
+    public AccessToken testToken() {
+        Token token = tokenFacade.issue("test-user-id");
+        return new AccessToken(token.accessToken());
+    }
+}

--- a/src/main/java/com/ssafy/foofa/identity/presentation/dto/AccessToken.java
+++ b/src/main/java/com/ssafy/foofa/identity/presentation/dto/AccessToken.java
@@ -1,0 +1,6 @@
+package com.ssafy.foofa.identity.presentation.dto;
+
+public record AccessToken(
+        String accessToken
+) {
+}

--- a/src/main/java/com/ssafy/foofa/identity/presentation/dto/LoginResponse.java
+++ b/src/main/java/com/ssafy/foofa/identity/presentation/dto/LoginResponse.java
@@ -1,0 +1,11 @@
+package com.ssafy.foofa.identity.presentation.dto;
+
+public record LoginResponse(
+        String userId,
+        String accessToken,
+        String refreshToken
+) {
+    public static LoginResponse of(String userId, String accessToken, String refreshToken) {
+        return new LoginResponse(userId, accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/ssafy/foofa/identity/presentation/dto/Token.java
+++ b/src/main/java/com/ssafy/foofa/identity/presentation/dto/Token.java
@@ -1,0 +1,7 @@
+package com.ssafy.foofa.identity.presentation.dto;
+
+public record Token(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/ssafy/foofa/identity/presentation/swagger/AuthSwagger.java
+++ b/src/main/java/com/ssafy/foofa/identity/presentation/swagger/AuthSwagger.java
@@ -1,0 +1,204 @@
+package com.ssafy.foofa.identity.presentation.swagger;
+
+import com.ssafy.foofa.core.ErrorResponse;
+import com.ssafy.foofa.identity.domain.enums.OauthProvider;
+import com.ssafy.foofa.identity.presentation.dto.AccessToken;
+import com.ssafy.foofa.identity.presentation.dto.LoginResponse;
+import com.ssafy.foofa.identity.presentation.dto.Token;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(
+        name = "Auth API",
+        description = """
+        <b>인증 관련 API입니다.</b><br><br>
+        <b>로그인 후 이용하는 API에서 발생 가능한 토큰 오류</b><br>
+        • <code>TOKEN_MISSING</code> : Authorization 헤더 없음<br>
+        • <code>INVALID_TOKEN_HEADER</code>: "Bearer " 접두사 누락<br>
+        • <code>TOKEN_EXPIRED</code> : Access Token 만료<br>
+        • <code>TOKEN_INVALID</code> : 위·변조 또는 형식 오류<br><br>
+        <b>🔑 OauthProvider ENUM</b> : <code>KAKAO</code> | <code>APPLE</code>
+        """
+)
+@RequestMapping("/auth")
+public interface AuthSwagger {
+
+    /*──────────────────────────────────────────────────────
+     * 1. OAuth 로그인
+     *──────────────────────────────────────────────────────*/
+    @Operation(
+            summary = "OAuth 로그인",
+            description = """
+            소셜 Access Token으로 로그인하고 자체 JWT Access/Refresh Token을 발급합니다.
+            """,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "로그인 성공",
+                            content = @Content(
+                                    schema = @Schema(implementation = LoginResponse.class),
+                                    examples = @ExampleObject(
+                                            value = """
+                        {
+                          "memberId": 99,
+                          "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                          "refreshToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                          "isNewMember": false
+                        }"""
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "지원하지 않는 provider / 파라미터 누락",
+                            content = @Content(
+                                    schema = @Schema(implementation = ErrorResponse.class),
+                                    examples = @ExampleObject(
+                                            value = """
+                        {
+                          "errorCode": "UNSUPPORTED_SOCIAL_LOGIN",
+                          "message": "지원하지 않는 소셜 로그인 타입입니다. type : NAVER"
+                        }"""
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "401",
+                            description = "소셜 토큰 만료·위조",
+                            content = @Content(
+                                    schema = @Schema(implementation = ErrorResponse.class),
+                                    examples = @ExampleObject(
+                                            value = """
+                        {
+                          "errorCode": "TOKEN_INVALID",
+                          "message": "유효하지 않은 토큰입니다. 다시 로그인해 주세요."
+                        }"""
+                                    )
+                            )
+                    )
+            }
+    )
+    @PostMapping("/login/oauth")
+    LoginResponse loginWithOAuth(
+            @Parameter(description = "OAuth 제공자", example = "KAKAO", required = true)
+            @RequestParam("provider") OauthProvider provider,
+            @Parameter(description = "소셜 Access Token", required = true)
+            @RequestParam("access_token") String accessToken
+    );
+
+    /*──────────────────────────────────────────────────────
+     * 2. 토큰 재발급
+     *──────────────────────────────────────────────────────*/
+    @Operation(
+            summary = "JWT 재발급",
+            description = """
+            쿠키에 저장된 Refresh Token으로 새 Access/Refresh Token을 발급합니다.<br>
+            """,
+            responses = {
+                    /*──── 200 : 성공 ─────────────────────────────*/
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "재발급 성공",
+                            content = @Content(schema = @Schema(implementation = Token.class))
+                    ),
+
+                    /*──── 401 : 인증 오류 모음 ───────────────────*/
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = """
+                            인증/토큰 관련 오류<br>
+                            • <code>MISSING_PARAMETER</code> - refreshToken 쿠키 누락<br>
+                            • <code>TOKEN_INVALID</code> - 토큰 위·변조 또는 형식 오류<br>
+                            • <code>REFRESH_TOKEN_EXPIRED</code> - 토큰 만료<br>
+                            """,
+                            content = @Content(
+                                    schema = @Schema(implementation = ErrorResponse.class),
+                                    examples = {
+                                            @ExampleObject(
+                                                    name = "MISSING_PARAMETER",
+                                                    summary = "refreshToken 쿠키 누락",
+                                                    value = """
+                        {
+                          "message": "필수 파라미터가 누락되었습니다."
+                        }"""
+                                            ),
+                                            @ExampleObject(
+                                                    name = "TOKEN_INVALID",
+                                                    summary = "토큰 위·변조 / 형식 오류",
+                                                    value = """
+                        {
+                          "message": "유효하지 않은 토큰입니다. 다시 로그인해 주세요."
+                        }"""
+                                            ),
+                                            @ExampleObject(
+                                                    name = "REFRESH_TOKEN_EXPIRED",
+                                                    summary = "Refresh Token 만료",
+                                                    value = """
+                        {
+                          "message": "리프레시 토큰이 만료되었습니다. 다시 로그인해 주세요."
+                        }"""
+                                            )
+                                    }
+                            )
+                    )
+            }
+    )
+    @PostMapping("/reissue")
+    Token reissue(
+            @Parameter(
+                    description = "Refresh Token (쿠키에서 자동으로 가져옴)",
+                    example     = "eyJhbGciOiJIUzI1NiJ9...",
+                    required    = true
+            )
+            @CookieValue("refreshToken") String refreshToken
+    );
+
+    /*──────────────────────────────────────────────────────
+     * 3. 로그아웃
+     *──────────────────────────────────────────────────────*/
+    @Operation(
+            summary = "로그아웃",
+            description = """
+            Refresh Token을 쿠키에서 제거합니다.<br>
+            """,
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "로그아웃 완료")
+            }
+    )
+    @PostMapping("/logout")
+    void logout(
+            HttpServletResponse response
+    );
+
+    /*──────────────────────────────────────────────────────
+     * 4. (개발용) Access Token 발급
+     *──────────────────────────────────────────────────────*/
+    @Operation(
+            summary = "테스트용 Access Token 발급",
+            description = "테스트 용으로 memberId = 1 사용자를 가정해 Access Token을 발급합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "발급 성공",
+                            content = @Content(
+                                    schema = @Schema(implementation = AccessToken.class),
+                                    examples = @ExampleObject(
+                                            value = """
+                        {
+                          "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                        }"""
+                                    )
+                            )
+                    )
+            }
+    )
+    @PostMapping("/test/token")
+    AccessToken testToken();
+}


### PR DESCRIPTION
## Issue Number
#1

## As-Is
<!-- Describe the current issue or problem -->
- `User` 엔티티가 `kakaoId` 필드에 의존하여 단일 플랫폼(카카오) 로그인만 가능한 구조
- 에러 처리 시 `ErrorCode` Enum이 `HttpStatus`와 강하게 결합되어 있어, 유동적인 에러 메시지 전달이나 단순 예외 처리에 유연성 부족
- OAuth 인증 로직, 토큰 발급/검증 로직, 비즈니스 로직이 명확한 계층 없이 혼재되거나 구체적인 구현체(Kakao)에 의존
- API 명세(Swagger) 및 JWT 관련 설정 관리 체계 미흡

## To-Be
<!-- Describe the intended changes or improvements -->
- **다중 소셜 로그인 지원 구조로 변경**: `User` 엔티티 내 `OauthInfo` (Provider, ProviderId) 도입 및 `OauthApiFactory` 패턴을 적용하여 확장성 확보
- **에러 핸들링 리팩토링**: `ErrorResponse` 및 `ErrorCode`에서 불필요한 결합을 제거하고, 메시지 중심의 유연한 전역 예외 처리(`GlobalExceptionHandler`) 구현
- **인증/인가 시스템 고도화**: JWT 발급·검증을 담당하는 `TokenManager` 및 이를 조정하는 `TokenFacade`, `AuthFacade`를 도입하여 역할과 책임 분리
- **API 명세** : `AuthSwagger` 인터페이스를 통한 API 문서화 

## ✅ Check List

- [x] Have all tests passed?
- [x] Have all commits been pushed?
- [x] Did you verify the target branch for the merge?
- [x] Did you assign the appropriate assignee(s)?
- [x] Did you set the correct label(s)?

## 📸 Test Screenshot

## Additional Description
